### PR TITLE
Fix typos in profile READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,11 @@
 
 ## ✍️ About Me
 
-I am a developer passionate about creating innovative and efficient solutions. With solid experience in PHP/Laravel, \ 
-JavaScript/Node.js, and Docker, I strive to continuously refine my expertise.
+I am a developer passionate about creating innovative and efficient solutions. With solid experience in PHP/Laravel, JavaScript/Node.js and Docker, I strive to continuously refine my expertise.
 
-I have a strong interest in SaaS deployment strategies, leveraging tools like Docker, Kubernetes, and AWS to deliver \
-robust and scalable solutions. When I'm not coding, I enjoy practicing combat sports, building LEGO with my family, \
-and  exploring new technologies.
+I have a strong interest in SaaS deployment strategies, leveraging tools like Docker, Kubernetes and AWS to deliver robust and scalable solutions. When I'm not coding, I enjoy practicing combat sports, building LEGO with my family, and exploring new technologies.
 
 > In the end, every system is like a giant LEGO sculpture, built from small pieces that fit together perfectly.
-
----
 
 ## 💼 Find Me Around
 

--- a/README_PT_BR.md
+++ b/README_PT_BR.md
@@ -11,12 +11,9 @@
 
 ## ✍️ Sobre Mim
 
-Sou um desenvolvedor apaixonado por criar soluções inovadoras e eficientes. Com sólida experiência em PHP/Laravel,  
-JavaScript/Node.js e Docker, busco constantemente aprimorar meu conhecimento e habilidades.
+Sou um desenvolvedor apaixonado por criar soluções inovadoras e eficientes. Com sólida experiência em PHP/Laravel, JavaScript/Node.js e Docker, busco constantemente aprimorar meu conhecimento e habilidades.
 
-Tenho especial interesse em estratégias de deploy para SaaS, utilizando ferramentas como Docker, Kubernetes e AWS para \
-criar soluções robustas e escaláveis. Quando não estou programando, gosto de praticar esportes de combate, \
-montar LEGO com minha família e explorar novas tecnologias.
+Tenho especial interesse em estratégias de deploy para SaaS, utilizando ferramentas como Docker, Kubernetes e AWS para criar soluções robustas e escaláveis. Quando não estou programando, gosto de praticar esportes de combate, montar LEGO com minha família e explorar novas tecnologias.
 
 > No fim, todo sistema é como uma grande escultura de LEGO, composta por pequenas peças que se encaixam perfeitamente.
 


### PR DESCRIPTION
## Summary
- fix English and Portuguese texts in about me sections

## Testing
- `codespell -q 3`
- `markdownlint README.md README_PT_BR.md` *(fails: line length and HTML warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68405f7e9974832e94f6f20b07b06f9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentação**
  - Melhorias na formatação das seções "Sobre Mim" e "About Me" nos arquivos de documentação, tornando o texto mais fluido e fácil de ler, sem alterações no conteúdo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->